### PR TITLE
Skip "no commit to master" check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
 
     - name: Run pre-commit
       run: python -m pre_commit run --all-files
+      env:
+        SKIP: no-commit-to-branch


### PR DESCRIPTION
Before this change, the check was causing CI failures on master.
Now it's skipped in the CI but is still effective on local envs.